### PR TITLE
remove trailing newline

### DIFF
--- a/src/openweathermap/main.py
+++ b/src/openweathermap/main.py
@@ -25,6 +25,7 @@ def __get_api_key() -> str:
         try:
             with open('.api.txt', 'r') as f:
                 res = f.read()
+                res = res.rstrip("\n")
         except IOError:
             pass
     if not res:


### PR DESCRIPTION
Many editors will add a trailing newline to the text rendering the API key broken. This change will make sure such "invisible" problems won't break the program.